### PR TITLE
feat: add deep trace logging to cognitive modules

### DIFF
--- a/app/modules/freeze_controller.py
+++ b/app/modules/freeze_controller.py
@@ -118,7 +118,20 @@ def should_freeze_loop(loop_plan: Dict[str, Any]) -> bool:
     # Check prompt text directly for freeze conditions
     if analyze_prompt_for_freeze_conditions(loop_plan):
         logger.warning("Freeze conditions found in prompt text")
+        # Add trace logging before returning True
+        trust_score = "undefined" if loop_plan.get("trust_undefined", False) else loop_plan.get("trust_score", "not_set")
+        freeze_triggered = True
+        print("[TRACE] Freeze Check – Trust Score:", trust_score)
+        print("[TRACE] Freeze Triggered:", freeze_triggered)
         return True
+    
+    # Get trust score for trace logging
+    trust_score = "undefined" if loop_plan.get("trust_undefined", False) else loop_plan.get("trust_score", "not_set")
+    freeze_triggered = False
+    
+    # Add trace logging
+    print("[TRACE] Freeze Check – Trust Score:", trust_score)
+    print("[TRACE] Freeze Triggered:", freeze_triggered)
     
     logger.info("No freeze triggers detected in loop plan")
     return False

--- a/app/modules/loop_execution_guard.py
+++ b/app/modules/loop_execution_guard.py
@@ -172,16 +172,32 @@ def loop_execution_guard(loop_plan: Dict[str, Any]) -> Dict[str, Any]:
     # Check if the loop should be frozen
     if should_freeze_loop(enriched_plan):
         logger.warning("Loop execution guard: Freezing loop due to trust or contradiction threshold")
-        return {"status": "frozen", "reason": "Trust or contradiction threshold triggered"}
+        # Add trace logging before returning frozen status
+        confidence_score = enriched_plan.get("confidence", "undefined")
+        trust_status = "undefined" if enriched_plan.get("trust_undefined", False) else get_trust_score(enriched_plan)
+        contradiction_score = len(enriched_plan.get("contradictions", []))
+        guard_result = {"status": "frozen", "reason": "Trust or contradiction threshold triggered"}
+        print("[TRACE] PROMPT:", loop_plan.get("prompt", "N/A"))
+        print("[TRACE] Confidence Score Parsed:", confidence_score)
+        print("[TRACE] Trust Status:", trust_status)
+        print("[TRACE] Contradiction Score:", contradiction_score)
+        print("[TRACE] Final Guard Status:", guard_result["status"])
+        return guard_result
 
     # Check if reflection is needed
     if should_reflect(enriched_plan):
         logger.info("Loop execution guard: Triggering recursive reflection")
-        return {
-            "status": "reflection-triggered",
-            "action": "recursive_reflection",
-            "reason": "Uncertainty or agent contradiction detected"
-        }
+        # Add trace logging before returning reflection status
+        confidence_score = enriched_plan.get("confidence", "undefined")
+        trust_status = "undefined" if enriched_plan.get("trust_undefined", False) else get_trust_score(enriched_plan)
+        contradiction_score = len(enriched_plan.get("contradictions", []))
+        guard_result = {"status": "reflection-triggered", "action": "recursive_reflection", "reason": "Uncertainty or agent contradiction detected"}
+        print("[TRACE] PROMPT:", loop_plan.get("prompt", "N/A"))
+        print("[TRACE] Confidence Score Parsed:", confidence_score)
+        print("[TRACE] Trust Status:", trust_status)
+        print("[TRACE] Contradiction Score:", contradiction_score)
+        print("[TRACE] Final Guard Status:", guard_result["status"])
+        return guard_result
     
     # Evaluate trust delta for logging purposes
     trust_delta = evaluate_trust_delta(enriched_plan)
@@ -191,6 +207,19 @@ def loop_execution_guard(loop_plan: Dict[str, Any]) -> Dict[str, Any]:
     trust_score = get_trust_score(enriched_plan)
     logger.info(f"Loop execution guard: Current trust score: {trust_score}")
     
+    # Extract values for trace logging
+    confidence_score = enriched_plan.get("confidence", "undefined")
+    trust_status = "undefined" if enriched_plan.get("trust_undefined", False) else get_trust_score(enriched_plan)
+    contradiction_score = len(enriched_plan.get("contradictions", []))
+    guard_result = {"status": "ok"}
+    
+    # Add trace logging
+    print("[TRACE] PROMPT:", loop_plan.get("prompt", "N/A"))
+    print("[TRACE] Confidence Score Parsed:", confidence_score)
+    print("[TRACE] Trust Status:", trust_status)
+    print("[TRACE] Contradiction Score:", contradiction_score)
+    print("[TRACE] Final Guard Status:", guard_result["status"])
+    
     # If all checks pass, return OK status
     logger.info("Loop execution guard: Loop plan accepted")
-    return {"status": "ok"}
+    return guard_result

--- a/app/modules/recursive_reflection_engine.py
+++ b/app/modules/recursive_reflection_engine.py
@@ -103,12 +103,30 @@ def should_reflect(loop_plan: Dict[str, Any]) -> bool:
     confidence = loop_plan.get("confidence", 1.0)
     if isinstance(confidence, (int, float)) and confidence < 0.5:
         logger.warning(f"Low confidence score detected: {confidence}, triggering reflection")
+        # Add trace logging before returning True
+        confidence_score = confidence
+        reflection_triggered = True
+        print("[TRACE] Reflection Check – Confidence:", confidence_score)
+        print("[TRACE] Recursive Reflection Triggered:", reflection_triggered)
         return True
     
     # Check prompt text directly for reflection conditions
     if analyze_prompt_for_reflection_conditions(loop_plan):
         logger.warning("Reflection conditions found in prompt text")
+        # Add trace logging before returning True
+        confidence_score = loop_plan.get("confidence", "undefined")
+        reflection_triggered = True
+        print("[TRACE] Reflection Check – Confidence:", confidence_score)
+        print("[TRACE] Recursive Reflection Triggered:", reflection_triggered)
         return True
+    
+    # Extract confidence score for trace logging
+    confidence_score = loop_plan.get("confidence", "undefined")
+    reflection_triggered = False
+    
+    # Add trace logging
+    print("[TRACE] Reflection Check – Confidence:", confidence_score)
+    print("[TRACE] Recursive Reflection Triggered:", reflection_triggered)
     
     logger.info("No reflection triggers detected in loop plan")
     return False

--- a/app/modules/trust_score_evaluator.py
+++ b/app/modules/trust_score_evaluator.py
@@ -68,6 +68,18 @@ def evaluate_trust_delta(loop_plan: Dict[str, Any]) -> float:
     """
     logger.info("Evaluating trust delta for loop plan")
     
+    # Get prompt text for trace logging
+    prompt = loop_plan.get("prompt", "N/A")
+    if not prompt and "loop_data" in loop_plan and isinstance(loop_plan["loop_data"], dict):
+        prompt = loop_plan["loop_data"].get("prompt", "N/A")
+    
+    # Determine trust state for trace logging
+    trust_result = "undefined" if loop_plan.get("trust_undefined", False) else loop_plan.get("trust_score", "not_set")
+    
+    # Add trace logging
+    print("[TRACE] Evaluating Trust – Raw Prompt:", prompt)
+    print("[TRACE] Parsed Agent Trust State:", trust_result)
+    
     # Check if trust is undefined or unknown
     if loop_plan.get("trust_undefined", False) or loop_plan.get("prompt_analysis", {}).get("trust_unknown", False):
         logger.warning("Trust is undefined or unknown, returning significant negative delta")


### PR DESCRIPTION
- Add trace logging to loop_execution_guard.py to show prompt, confidence, trust, and contradiction scores
- Add trace logging to freeze_controller.py to show trust score and freeze decision
- Add trace logging to recursive_reflection_engine.py to show confidence and reflection decision
- Add trace logging to trust_score_evaluator.py to show raw prompt and parsed trust state
- Ensure trace logs appear in all execution paths