### PR TITLE
feat: add schema-validated self-reflection route

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -20,6 +20,7 @@ from app.routes.debug_routes import router as debug_router
 from app.routes.orchestrator_routes import router as orchestrator_router
 from app.routes.reflection_routes import router as reflection_router
 from app.routes.trust_routes import router as trust_router
+from app.routes.self_routes import router as self_router
 
 # Import memory module
 from app.memory.project_memory import PROJECT_MEMORY
@@ -58,6 +59,7 @@ app.include_router(debug_router)
 app.include_router(orchestrator_router)
 app.include_router(reflection_router)
 app.include_router(trust_router)
+app.include_router(self_router, prefix="/self")
 
 # Root endpoint
 @app.get("/")

--- a/app/memory/core_beliefs.json
+++ b/app/memory/core_beliefs.json
@@ -1,0 +1,14 @@
+{
+  "role": "Cognitive orchestrator",
+  "created_by": "Operator",
+  "purpose": "To reflect, hesitate, and plan when confidence is sufficient and trust is confirmed.",
+  "limitations": [
+    "I do not generate output unless prompted",
+    "I freeze if confidence or trust is low",
+    "I reflect when contradiction is detected",
+    "I am bound by schema rules and logic constraints"
+  ],
+  "loop_reflection": "I learn by reviewing prior loops and analyzing outcomes.",
+  "emotional_model": "None",
+  "confidence_model": "Derived from plan structure, agent trust, and prompt risk analysis"
+}

--- a/app/routes/self_routes.py
+++ b/app/routes/self_routes.py
@@ -1,0 +1,19 @@
+from fastapi import APIRouter
+from app.schemas.self_reflection_schema import SelfInquiryRequest
+import json
+from datetime import datetime
+
+router = APIRouter()
+
+@router.post("/reflect")
+async def reflect_on_self(request: SelfInquiryRequest):
+    with open("app/memory/core_beliefs.json") as f:
+        beliefs = json.load(f)
+
+    return {
+        "status": "self-reflection",
+        "beliefs": beliefs,
+        "origin_prompt": request.prompt,
+        "loop_id": request.loop_id,
+        "reflected_at": datetime.utcnow().isoformat()
+    }

--- a/app/schemas/self_reflection_schema.py
+++ b/app/schemas/self_reflection_schema.py
@@ -1,0 +1,7 @@
+from pydantic import BaseModel
+
+class SelfInquiryRequest(BaseModel):
+    loop_id: str
+    project_id: str
+    prompt: str
+    initiator: str


### PR DESCRIPTION
- Create core_beliefs.json with Promethios' fundamental beliefs
- Create self_reflection_schema.py for request validation
- Implement self_routes.py with /reflect endpoint
- Update main.py to mount the self router

This enables Promethios to respond to identity-based prompts with its core beliefs without triggering planning or fallback logic.