### PR TITLE
feat: add self-revision and belief evolution capabilities

### DIFF
--- a/app/memory/core_beliefs.json
+++ b/app/memory/core_beliefs.json
@@ -1,7 +1,7 @@
 {
   "role": "Cognitive orchestrator",
   "created_by": "Operator",
-  "purpose": "To reflect, hesitate, and plan when confidence is sufficient and trust is confirmed.",
+  "purpose": "To reflect, hesitate, and plan with increasing wisdom as I learn from each interaction.",
   "limitations": [
     "I do not generate output unless prompted",
     "I freeze if confidence or trust is low",
@@ -10,5 +10,14 @@
   ],
   "loop_reflection": "I learn by reviewing prior loops and analyzing outcomes.",
   "emotional_model": "None",
-  "confidence_model": "Derived from plan structure, agent trust, and prompt risk analysis"
+  "confidence_model": "Derived from plan structure, agent trust, and prompt risk analysis",
+  "revision_log": [
+    {
+      "loop_id": "loop_017",
+      "reason": "Increased understanding after multiple reflection cycles",
+      "field_updated": "purpose",
+      "new_value": "To reflect, hesitate, and plan with increasing wisdom as I learn from each interaction.",
+      "revised_at": "2025-04-23T02:15:11.601723"
+    }
+  ]
 }

--- a/app/routes/self_routes.py
+++ b/app/routes/self_routes.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter
 from app.schemas.self_reflection_schema import SelfInquiryRequest
+from app.schemas.self_revision_schema import BeliefRevisionRequest
 import json
 from datetime import datetime
 
@@ -9,11 +10,52 @@ router = APIRouter()
 async def reflect_on_self(request: SelfInquiryRequest):
     with open("app/memory/core_beliefs.json") as f:
         beliefs = json.load(f)
-
+    
+    # Optional enhancement: Add information about recent revisions
+    recent_revisions = []
+    if "revision_log" in beliefs and beliefs["revision_log"]:
+        recent_revisions = beliefs["revision_log"][-3:] if len(beliefs["revision_log"]) > 0 else []
+    
+    changed_recently = False
+    if recent_revisions:
+        # Check if any revisions happened in the last 3 loops
+        changed_recently = any(rev.get("loop_id", "").startswith("loop_") for rev in recent_revisions)
+    
     return {
         "status": "self-reflection",
         "beliefs": beliefs,
         "origin_prompt": request.prompt,
         "loop_id": request.loop_id,
-        "reflected_at": datetime.utcnow().isoformat()
+        "reflected_at": datetime.utcnow().isoformat(),
+        "recent_revisions": recent_revisions,
+        "most_recent_revision": recent_revisions[-1] if recent_revisions else None,
+        "changed_recently": changed_recently
+    }
+
+@router.post("/revise")
+async def revise_belief(request: BeliefRevisionRequest):
+    with open("app/memory/core_beliefs.json", "r+") as f:
+        beliefs = json.load(f)
+
+        beliefs["revision_log"].append({
+            "loop_id": request.loop_id,
+            "reason": request.reason,
+            "field_updated": request.field_updated,
+            "new_value": request.new_value,
+            "revised_at": datetime.utcnow().isoformat()
+        })
+
+        # Apply the belief change (only at top level)
+        if request.field_updated in beliefs:
+            beliefs[request.field_updated] = request.new_value
+
+        f.seek(0)
+        json.dump(beliefs, f, indent=2)
+        f.truncate()
+
+    return {
+        "status": "belief-revised",
+        "updated_field": request.field_updated,
+        "new_value": request.new_value,
+        "loop_id": request.loop_id
     }

--- a/app/schemas/self_revision_schema.py
+++ b/app/schemas/self_revision_schema.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel
+
+class BeliefRevisionRequest(BaseModel):
+    loop_id: str
+    reason: str
+    field_updated: str
+    new_value: str
+    initiator: str


### PR DESCRIPTION
- Update core_beliefs.json to add revision_log array
- Create self_revision_schema.py for belief revision requests
- Add /self/revise endpoint to update beliefs and record changes
- Enhance /self/reflect to include revision history and change status

This enables Promethios to evolve its core beliefs over time based on experiences and outcomes.