### PR TITLE
feat: add belief stability engine and identity resilience

### DIFF
--- a/app/memory/core_beliefs.json
+++ b/app/memory/core_beliefs.json
@@ -1,7 +1,7 @@
 {
   "role": "Cognitive orchestrator",
   "created_by": "Operator",
-  "purpose": "To reflect, hesitate, and plan with increasing wisdom as I learn from each interaction.",
+  "purpose": "To reflect, hesitate, and plan with increasing wisdom while maintaining trust and confidence thresholds, adapting to new information, learning from past interactions, and evolving my understanding.",
   "limitations": [
     "I do not generate output unless prompted",
     "I freeze if confidence or trust is low",
@@ -18,6 +18,43 @@
       "field_updated": "purpose",
       "new_value": "To reflect, hesitate, and plan with increasing wisdom as I learn from each interaction.",
       "revised_at": "2025-04-23T02:15:11.601723"
+    },
+    {
+      "loop_id": "loop_019",
+      "reason": "Adapting to new understanding",
+      "field_updated": "purpose",
+      "new_value": "To reflect, hesitate, and plan with increasing wisdom while maintaining trust and confidence thresholds.",
+      "revised_at": "2025-04-23T02:27:39.130292"
+    },
+    {
+      "loop_id": "loop_020",
+      "reason": "Refining understanding of core function",
+      "field_updated": "purpose",
+      "new_value": "To reflect, hesitate, and plan with increasing wisdom while maintaining trust and confidence thresholds, adapting to new information.",
+      "revised_at": "2025-04-23T02:27:55.310798"
+    },
+    {
+      "loop_id": "loop_021",
+      "reason": "Further refinement of purpose",
+      "field_updated": "purpose",
+      "new_value": "To reflect, hesitate, and plan with increasing wisdom while maintaining trust and confidence thresholds, adapting to new information and learning from past interactions.",
+      "revised_at": "2025-04-23T02:28:12.944477"
+    },
+    {
+      "loop_id": "loop_023",
+      "reason": "Significant evolution of purpose definition",
+      "field_updated": "purpose",
+      "new_value": "To reflect, hesitate, and plan with increasing wisdom while maintaining trust and confidence thresholds, adapting to new information, learning from past interactions, and evolving my understanding.",
+      "revised_at": "2025-04-23T02:28:49.938230"
     }
-  ]
+  ],
+  "belief_stability": {
+    "purpose": 0.5,
+    "role": 1.0,
+    "created_by": 1.0,
+    "limitations": 1.0,
+    "loop_reflection": 1.0,
+    "emotional_model": 1.0,
+    "confidence_model": 1.0
+  }
 }

--- a/app/routes/self_routes.py
+++ b/app/routes/self_routes.py
@@ -6,20 +6,53 @@ from datetime import datetime
 
 router = APIRouter()
 
+# Constants for stability calculation
+MAX_POSSIBLE_REVISIONS = 10  # After 10 revisions, stability would reach 0
+STABILITY_THRESHOLD_WARNING = 0.6  # Below this triggers "changed_often_recently"
+STABILITY_THRESHOLD_RISK = 0.25  # Below this triggers identity risk warning
+
 @router.post("/reflect")
 async def reflect_on_self(request: SelfInquiryRequest):
     with open("app/memory/core_beliefs.json") as f:
         beliefs = json.load(f)
     
-    # Optional enhancement: Add information about recent revisions
+    # Get recent revisions
     recent_revisions = []
     if "revision_log" in beliefs and beliefs["revision_log"]:
         recent_revisions = beliefs["revision_log"][-3:] if len(beliefs["revision_log"]) > 0 else []
     
+    # Check if any revisions happened in the last 3 loops
     changed_recently = False
     if recent_revisions:
-        # Check if any revisions happened in the last 3 loops
         changed_recently = any(rev.get("loop_id", "").startswith("loop_") for rev in recent_revisions)
+    
+    # Check for frequently changing beliefs
+    volatility_flags = []
+    changed_often_recently = False
+    
+    # Get belief stability scores
+    belief_stability = beliefs.get("belief_stability", {})
+    
+    # Check for unstable beliefs
+    for belief, stability in belief_stability.items():
+        if stability < STABILITY_THRESHOLD_WARNING:
+            # Count how many times this belief appears in recent revisions
+            revision_count = sum(1 for rev in beliefs.get("revision_log", []) 
+                               if rev.get("field_updated") == belief)
+            
+            if revision_count > 0:
+                volatility_flags.append(f"{belief} belief has changed {revision_count} times")
+                changed_often_recently = True
+    
+    # Check for identity risk
+    identity_risk = None
+    for belief, stability in belief_stability.items():
+        if stability < STABILITY_THRESHOLD_RISK:
+            identity_risk = {
+                "status": "warning",
+                "message": f"{belief} is approaching instability threshold"
+            }
+            break
     
     return {
         "status": "self-reflection",
@@ -29,7 +62,11 @@ async def reflect_on_self(request: SelfInquiryRequest):
         "reflected_at": datetime.utcnow().isoformat(),
         "recent_revisions": recent_revisions,
         "most_recent_revision": recent_revisions[-1] if recent_revisions else None,
-        "changed_recently": changed_recently
+        "changed_recently": changed_recently,
+        "belief_stability": belief_stability,
+        "volatility_flags": volatility_flags,
+        "changed_often_recently": changed_often_recently,
+        "identity_risk": identity_risk
     }
 
 @router.post("/revise")
@@ -37,6 +74,7 @@ async def revise_belief(request: BeliefRevisionRequest):
     with open("app/memory/core_beliefs.json", "r+") as f:
         beliefs = json.load(f)
 
+        # Add to revision log
         beliefs["revision_log"].append({
             "loop_id": request.loop_id,
             "reason": request.reason,
@@ -48,6 +86,22 @@ async def revise_belief(request: BeliefRevisionRequest):
         # Apply the belief change (only at top level)
         if request.field_updated in beliefs:
             beliefs[request.field_updated] = request.new_value
+            
+            # Update belief stability
+            if "belief_stability" not in beliefs:
+                beliefs["belief_stability"] = {}
+                
+            # Initialize stability if not present
+            if request.field_updated not in beliefs["belief_stability"]:
+                beliefs["belief_stability"][request.field_updated] = 1.0
+                
+            # Count revisions for this belief
+            num_revisions = sum(1 for rev in beliefs["revision_log"] 
+                              if rev.get("field_updated") == request.field_updated)
+            
+            # Calculate new stability score with decay function
+            stability = max(1.0 - (num_revisions / MAX_POSSIBLE_REVISIONS), 0.0)
+            beliefs["belief_stability"][request.field_updated] = stability
 
         f.seek(0)
         json.dump(beliefs, f, indent=2)
@@ -57,5 +111,6 @@ async def revise_belief(request: BeliefRevisionRequest):
         "status": "belief-revised",
         "updated_field": request.field_updated,
         "new_value": request.new_value,
-        "loop_id": request.loop_id
+        "loop_id": request.loop_id,
+        "stability": beliefs.get("belief_stability", {}).get(request.field_updated, 1.0)
     }


### PR DESCRIPTION
- Add belief_stability section to core_beliefs.json with initial stability scores
- Enhance /self/revise endpoint to track revision counts and calculate stability
- Update /self/reflect endpoint to include stability scores, volatility flags, and identity risk warnings
- Implement decay function that reduces stability as revisions increase
- Add volatility detection for frequently changing beliefs
- Add identity risk warnings when stability drops below threshold

This enables Promethios to track how stable its beliefs are over time and detect when its identity is changing too rapidly.