### PR TITLE
feat: add self-reinforcement and identity anchoring

### DIFF
--- a/app/memory/core_beliefs.json
+++ b/app/memory/core_beliefs.json
@@ -56,5 +56,42 @@
     "loop_reflection": 1.0,
     "emotional_model": 1.0,
     "confidence_model": 1.0
+  },
+  "reinforced_beliefs": {
+    "purpose": {
+      "last_reinforced_at": "2025-04-23T03:04:59.598150",
+      "reinforcement_reason": "Operator affirmed alignment after 5 revisions",
+      "locked": true
+    },
+    "role": {
+      "last_reinforced_at": null,
+      "reinforcement_reason": null,
+      "locked": false
+    },
+    "created_by": {
+      "last_reinforced_at": null,
+      "reinforcement_reason": null,
+      "locked": false
+    },
+    "limitations": {
+      "last_reinforced_at": null,
+      "reinforcement_reason": null,
+      "locked": false
+    },
+    "loop_reflection": {
+      "last_reinforced_at": null,
+      "reinforcement_reason": null,
+      "locked": false
+    },
+    "emotional_model": {
+      "last_reinforced_at": null,
+      "reinforcement_reason": null,
+      "locked": false
+    },
+    "confidence_model": {
+      "last_reinforced_at": null,
+      "reinforcement_reason": null,
+      "locked": false
+    }
   }
 }

--- a/app/schemas/self_reinforcement_schema.py
+++ b/app/schemas/self_reinforcement_schema.py
@@ -1,0 +1,7 @@
+from pydantic import BaseModel
+
+class BeliefReinforcementRequest(BaseModel):
+    loop_id: str
+    field: str
+    reinforcement_reason: str
+    initiator: str


### PR DESCRIPTION
- Create new BeliefReinforcementRequest schema
- Add reinforced_beliefs tracking to core_beliefs.json
- Implement /self/reinforce endpoint to lock beliefs
- Protect /self/revise endpoint from modifying locked beliefs
- Enhance /self/reflect endpoint to show reinforcement status

This enables Promethios to reinforce beliefs that have become unstable, preventing further revision for a defined period and recording why the reinforcement occurred, creating the foundation for identity anchoring.