### PR TITLE
Add self-challenge and belief resilience functionality

### DIFF
--- a/app/memory/core_beliefs.json
+++ b/app/memory/core_beliefs.json
@@ -93,5 +93,15 @@
       "reinforcement_reason": null,
       "locked": false
     }
+  },
+  "challenge_log": {
+    "purpose": [
+      {
+        "loop_id": "loop_026",
+        "challenger": "CRITIC",
+        "reason": "Purpose statement lacks clarity on ethical boundaries",
+        "challenged_at": "2025-04-23T03:54:34.342301"
+      }
+    ]
   }
 }

--- a/app/schemas/self_challenge_schema.py
+++ b/app/schemas/self_challenge_schema.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel
+
+class BeliefChallengeRequest(BaseModel):
+    loop_id: str
+    field: str
+    challenger: str
+    challenge_reason: str
+    initiator: str


### PR DESCRIPTION
- Create BeliefChallengeRequest schema for tracking challenges
- Add challenge_log to core_beliefs.json for storing challenges
- Implement /self/challenge endpoint for recording challenges
- Enhance /self/reflect endpoint to show challenge information
- Add under_review state for frequently challenged beliefs