### PR TITLE
fix: add "requests" dependency and modernize schema configs

### DIFF
--- a/app/api/control.py
+++ b/app/api/control.py
@@ -38,7 +38,7 @@ class AgentTaskRequest(BaseModel):
     task: Optional[Dict[str, Any]] = None
 
     class Config:
-        schema_extra = {
+        json_schema_extra = {
             "example": {
                 "agent_id": "builder-1",
                 "task": {

--- a/app/models/workflow.py
+++ b/app/models/workflow.py
@@ -46,7 +46,7 @@ class WorkflowResponse(BaseModel):
     total_steps: int = 0
     
     class Config:
-        schema_extra = {
+        json_schema_extra = {
             "example": {
                 "steps": [
                     {

--- a/app/schemas/loop_schema.py
+++ b/app/schemas/loop_schema.py
@@ -18,7 +18,7 @@ class LoopResponseRequest(BaseModel):
     target_file: Optional[str] = Field(None, description="Target file for code responses, required if response_type is 'code'")
     
     class Config:
-        schema_extra = {
+        json_schema_extra = {
             "example": {
                 "loop_id": "loop_123456",
                 "project_id": "project_789012",

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fastapi>=0.68.0
 uvicorn>=0.15.0
 pytest>=6.2.5
 jsonschema>=4.0.0
+requests>=2.31.0


### PR DESCRIPTION
This PR fixes the missing "requests" dependency and updates deprecated Pydantic schema config keys.

✅ Added:
- `requests>=2.31.0` to requirements.txt (fixes ModuleNotFoundError on Railway)

🔧 Modernized:
- Updated `schema_extra` to `json_schema_extra` in:
  - app/api/control.py
  - app/models/workflow.py
  - app/schemas/loop_schema.py

Confirmed via test deployment. This resolves Railway deployment errors and removes Pydantic deprecation warnings.