### PR TITLE
🛠️ PATCH: Add /api prefix to loop_routes

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -52,7 +52,7 @@ async def add_process_time_header(request: Request, call_next):
 
 # Include routers
 app.include_router(core_router)
-app.include_router(loop_router)
+app.include_router(loop_router, prefix="/api")
 app.include_router(agent_router)
 app.include_router(persona_router)
 app.include_router(debug_router)


### PR DESCRIPTION
- Added prefix='/api' when including loop_router in main.py
- Ensures routes like /loop/respond become /api/loop/respond
- Fixes 404 error in deployed Railway environment

Tag: fix-loop-router-prefix