### PR TITLE
chore: add stub routes for reflection and trust modules

### DIFF
--- a/routes/reflection_routes.py
+++ b/routes/reflection_routes.py
@@ -1,0 +1,31 @@
+"""
+Reflection Routes Module
+This module defines the reflection-related routes for the Promethios API.
+It provides a stub endpoint for reflection functionality to stabilize the route system.
+This stub implementation will be expanded in future for use by agents like sage,
+guardian, or belief alignment layers.
+"""
+from fastapi import APIRouter
+from typing import Dict, Any
+from pydantic import BaseModel
+
+# Create router with appropriate tag
+router = APIRouter(tags=["reflection"])
+
+class ReflectionResponse(BaseModel):
+    status: str
+    message: str
+
+@router.get("/reflection/test", response_model=ReflectionResponse)
+async def reflection_stub() -> Dict[str, Any]:
+    """
+    Test endpoint for the reflection route system.
+    Returns a simple status message indicating the reflection route is active.
+    
+    Returns:
+        Dict[str, Any]: A dictionary containing status information
+    """
+    return {
+        "status": "reflection route active",
+        "message": "Reflection module stub endpoint is functioning correctly"
+    }

--- a/routes/trust_routes.py
+++ b/routes/trust_routes.py
@@ -1,0 +1,31 @@
+"""
+Trust Routes Module
+This module defines the trust-related routes for the Promethios API.
+It provides a stub endpoint for trust functionality to stabilize the route system.
+This stub implementation will be expanded in future for use by agents like sage,
+guardian, or belief alignment layers.
+"""
+from fastapi import APIRouter
+from typing import Dict, Any
+from pydantic import BaseModel
+
+# Create router with appropriate tag
+router = APIRouter(tags=["trust"])
+
+class TrustResponse(BaseModel):
+    status: str
+    message: str
+
+@router.get("/trust/test", response_model=TrustResponse)
+async def trust_stub() -> Dict[str, Any]:
+    """
+    Test endpoint for the trust route system.
+    Returns a simple status message indicating the trust route is active.
+    
+    Returns:
+        Dict[str, Any]: A dictionary containing status information
+    """
+    return {
+        "status": "trust route active",
+        "message": "Trust module stub endpoint is functioning correctly"
+    }


### PR DESCRIPTION
- Created reflection_routes.py in routes/ directory with test endpoint
- Created trust_routes.py in routes/ directory with test endpoint
- Both modules include proper schema structure with Pydantic models
- Implemented as per requirements to stabilize the route system
- Prepared for future use by agents like sage, guardian, or belief alignment layers

Tag: core/stub-reflection-trust