### PR TITLE
Hotfix: Fix retry_with_backoff decorator parameter names in health_monitor.py

### DIFF
--- a/app/modules/health_monitor.py
+++ b/app/modules/health_monitor.py
@@ -170,7 +170,7 @@ class HealthMonitor:
             }
         }
 
-    @retry_with_backoff(max_retries=3, base_delay=1, backoff_factor=2)
+    @retry_with_backoff(retries=3, backoff=2)
     async def check_health(self, request: HealthCheckRequest) -> HealthCheckResponse:
         """
         Perform a health check on the specified component or the entire system.
@@ -949,7 +949,7 @@ class HealthMonitor:
         except Exception as e:
             logger.error(f"Error saving health check history: {str(e)}")
 
-    @retry_with_backoff(max_retries=3, base_delay=1, backoff_factor=2)
+    @retry_with_backoff(retries=3, backoff=2)
     async def predict_maintenance(
         self, request: PredictiveMaintenanceRequest
     ) -> PredictiveMaintenanceResponse:
@@ -1374,7 +1374,7 @@ class HealthMonitor:
         except Exception as e:
             logger.error(f"Error saving predictions: {str(e)}")
 
-    @retry_with_backoff(max_retries=3, base_delay=1, backoff_factor=2)
+    @retry_with_backoff(retries=3, backoff=2)
     async def perform_self_healing(self, request: SelfHealingRequest) -> SelfHealingResponse:
         """
         Perform self-healing actions on a component.
@@ -1636,7 +1636,7 @@ class HealthMonitor:
         except Exception as e:
             logger.error(f"Error saving healing actions: {str(e)}")
 
-    @retry_with_backoff(max_retries=3, base_delay=1, backoff_factor=2)
+    @retry_with_backoff(retries=3, backoff=2)
     async def update_config(self, request: HealthMonitorConfigRequest) -> HealthMonitorConfigResponse:
         """
         Update health monitor configuration.

--- a/fix_decorator.py
+++ b/fix_decorator.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""
+Fix retry_with_backoff decorator usage in health_monitor.py
+
+This script updates all occurrences of the retry_with_backoff decorator in 
+health_monitor.py to use the correct parameter names.
+"""
+
+import re
+
+def fix_decorator_usage(file_path):
+    """
+    Fix the retry_with_backoff decorator usage in the specified file.
+    
+    Args:
+        file_path: Path to the file to fix
+    """
+    # Read the file content
+    with open(file_path, 'r') as f:
+        content = f.read()
+    
+    # Replace all occurrences of the decorator with the correct parameter names
+    fixed_content = re.sub(
+        r'@retry_with_backoff\(max_retries=3, base_delay=1, backoff_factor=2\)',
+        '@retry_with_backoff(retries=3, backoff=2)',
+        content
+    )
+    
+    # Write the fixed content back to the file
+    with open(file_path, 'w') as f:
+        f.write(fixed_content)
+    
+    print(f"✅ Fixed retry_with_backoff decorator usage in {file_path}")
+
+if __name__ == "__main__":
+    file_path = "app/modules/health_monitor.py"
+    fix_decorator_usage(file_path)


### PR DESCRIPTION
## Hotfix: retry_with_backoff Decorator Crash Recovery

### Issue
The backend was failing to boot due to a TypeError in health_monitor.py caused by incorrect parameter names in the retry_with_backoff decorator.

### Root Cause
The decorator was being called with `max_retries=3, base_delay=1, backoff_factor=2` but the actual decorator implementation in retry_handler.py expects `retries` and `backoff` parameters instead.

### Fix
- Changed `max_retries=3` to `retries=3`
- Changed `base_delay=1, backoff_factor=2` to `backoff=2`
- Fixed all 4 occurrences of the decorator in health_monitor.py

### Testing
- Verified that the decorator can be imported without errors
- Confirmed no TypeError occurs when importing the decorator

### Memory Tag
hotfix_retry_backoff_20250424