### PR TITLE
Fix JSON parsing error in core_beliefs.json

### DIFF
--- a/app/memory/core_beliefs.json
+++ b/app/memory/core_beliefs.json
@@ -61,37 +61,37 @@
     "purpose": {
       "last_reinforced_at": "2025-04-23T03:04:59.598150",
       "reinforcement_reason": "Operator affirmed alignment after 5 revisions",
-      "locked": True
+      "locked": true
     },
     "role": {
       "last_reinforced_at": null,
       "reinforcement_reason": null,
-      "locked": False
+      "locked": false
     },
     "created_by": {
       "last_reinforced_at": null,
       "reinforcement_reason": null,
-      "locked": False
+      "locked": false
     },
     "limitations": {
       "last_reinforced_at": null,
       "reinforcement_reason": null,
-      "locked": False
+      "locked": false
     },
     "loop_reflection": {
       "last_reinforced_at": null,
       "reinforcement_reason": null,
-      "locked": False
+      "locked": false
     },
     "emotional_model": {
       "last_reinforced_at": null,
       "reinforcement_reason": null,
-      "locked": False
+      "locked": false
     },
     "confidence_model": {
       "last_reinforced_at": null,
       "reinforcement_reason": null,
-      "locked": False
+      "locked": false
     }
   },
   "challenge_log": {


### PR DESCRIPTION
## Summary

This PR fixes the JSON parsing error in `core_beliefs.json` that was causing the agent_sdk to fail with the error: "Expecting value: line 64 column 17 (char 2846)".

## Changes

- Fixed Python-style boolean values (`True`/`False`) to JSON-standard lowercase (`true`/`false`) in `app/memory/core_beliefs.json`
- This resolves the JSON parsing error that was preventing the agent_sdk from loading schemas correctly

## Testing

- Verified that the file now parses correctly with no errors
- All JSON files in the target directories now pass validation

## Memory Tag
`final_schema_hunt_20250424_222031`