### PR TITLE
fix: Add HAL schema file in expected runtime path

### DIFF
--- a/app/schemas/hal_agent.schema.json
+++ b/app/schemas/hal_agent.schema.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "HALAgentContract",
+  "type": "object",
+  "properties": {
+    "input": {
+      "type": "string"
+    },
+    "context": {
+      "type": "string"
+    },
+    "output": {
+      "type": "string"
+    }
+  },
+  "required": ["input", "output"]
+}


### PR DESCRIPTION
This PR fixes the HAL schema path mismatch issue discovered during verification:

- The HAL schema file exists in the repository at app/schemas/schemas/hal_agent.schema.json
- However, the system looks for it at app/schemas/hal_agent.schema.json at runtime
- This path mismatch was causing HAL to load in fallback/degraded mode
- This PR adds the schema file in the expected runtime path to fix the issue

The verification details have been logged to logs/hal_schema_verification_20250425_130919.json
and the system manifest has been updated with memory tag: hal_schema_status_checked_20250425_130953