### PR TITLE
Fix memory module parameter mismatches to resolve dashboard issues

### DIFF
--- a/app/modules/memory_writer.py
+++ b/app/modules/memory_writer.py
@@ -1,9 +1,12 @@
 """
 Memory writer module for writing and reading memory entries
+
+This module provides functions for writing and reading memory entries,
+with support for different agent types and memory categories.
 """
 import logging
 import datetime
-from typing import Dict, Any, Optional
+from typing import Dict, Any, Optional, List, Union
 
 # Configure logging
 logger = logging.getLogger("app.modules.memory_writer")
@@ -11,33 +14,49 @@ logger = logging.getLogger("app.modules.memory_writer")
 # In-memory storage for testing
 MEMORY_STORE = {}
 
-async def write_memory(project_id: str, tag: str, value: Any) -> Dict[str, Any]:
+async def write_memory(
+    agent_id: str,
+    memory_type: str,
+    tag: str,
+    value: Any,
+    project_id: Optional[str] = None
+) -> Dict[str, Any]:
     """
     Write a memory entry to the memory system.
     
     Args:
-        project_id: The project identifier
+        agent_id: The agent identifier
+        memory_type: Type of memory (e.g., "loop", "state", "reflection")
         tag: The memory tag
         value: The memory value to store
+        project_id: Optional project identifier
             
     Returns:
         Dict containing status and memory entry details
     """
     try:
-        logger.info(f"Writing memory for project: {project_id}, tag: {tag}")
+        logger.info(f"Writing memory for agent: {agent_id}, type: {memory_type}, tag: {tag}")
+        
+        # Use agent_id as key if project_id not provided
+        store_key = project_id if project_id else agent_id
         
         # Store in memory dictionary for testing
-        if project_id not in MEMORY_STORE:
-            MEMORY_STORE[project_id] = {}
-        
-        MEMORY_STORE[project_id][tag] = value
+        if store_key not in MEMORY_STORE:
+            MEMORY_STORE[store_key] = {}
+            
+        if memory_type not in MEMORY_STORE[store_key]:
+            MEMORY_STORE[store_key][memory_type] = {}
+            
+        MEMORY_STORE[store_key][memory_type][tag] = value
         
         # Return success response
         return {
             "status": "success",
             "message": "Memory write successful",
-            "project_id": project_id,
+            "agent_id": agent_id,
+            "memory_type": memory_type,
             "tag": tag,
+            "project_id": project_id,
             "timestamp": datetime.datetime.now().isoformat()
         }
     except Exception as e:
@@ -48,26 +67,126 @@ async def write_memory(project_id: str, tag: str, value: Any) -> Dict[str, Any]:
             "timestamp": datetime.datetime.now().isoformat()
         }
 
-async def read_memory(project_id: str, tag: str) -> Optional[Any]:
+async def read_memory(
+    agent_id: str,
+    memory_type: str,
+    tag: str,
+    project_id: Optional[str] = None
+) -> Dict[str, Any]:
     """
     Read a memory entry from the memory system.
     
     Args:
-        project_id: The project identifier
+        agent_id: The agent identifier
+        memory_type: Type of memory (e.g., "loop", "state", "reflection")
         tag: The memory tag
+        project_id: Optional project identifier
             
     Returns:
-        The memory value if found, None otherwise
+        Dict containing status and memory value if found
     """
     try:
-        logger.info(f"Reading memory for project: {project_id}, tag: {tag}")
+        logger.info(f"Reading memory for agent: {agent_id}, type: {memory_type}, tag: {tag}")
+        
+        # Use agent_id as key if project_id not provided
+        store_key = project_id if project_id else agent_id
         
         # Read from memory dictionary for testing
-        if project_id in MEMORY_STORE and tag in MEMORY_STORE[project_id]:
-            return MEMORY_STORE[project_id][tag]
+        if (store_key in MEMORY_STORE and 
+            memory_type in MEMORY_STORE[store_key] and 
+            tag in MEMORY_STORE[store_key][memory_type]):
+            
+            return {
+                "status": "success",
+                "value": MEMORY_STORE[store_key][memory_type][tag],
+                "agent_id": agent_id,
+                "memory_type": memory_type,
+                "tag": tag,
+                "project_id": project_id,
+                "timestamp": datetime.datetime.now().isoformat()
+            }
         
-        logger.warning(f"Memory not found for project: {project_id}, tag: {tag}")
-        return None
+        logger.warning(f"Memory not found for agent: {agent_id}, type: {memory_type}, tag: {tag}")
+        return {
+            "status": "not_found",
+            "message": "Memory entry not found",
+            "agent_id": agent_id,
+            "memory_type": memory_type,
+            "tag": tag,
+            "project_id": project_id,
+            "timestamp": datetime.datetime.now().isoformat()
+        }
     except Exception as e:
         logger.error(f"Error reading memory: {str(e)}")
-        return None
+        return {
+            "status": "error",
+            "message": f"Failed to read memory: {str(e)}",
+            "timestamp": datetime.datetime.now().isoformat()
+        }
+
+async def list_memories(
+    agent_id: str,
+    memory_type: str,
+    tag_prefix: Optional[str] = None,
+    project_id: Optional[str] = None
+) -> Dict[str, Any]:
+    """
+    List memory entries matching the specified criteria.
+    
+    Args:
+        agent_id: The agent identifier
+        memory_type: Type of memory (e.g., "loop", "state", "reflection")
+        tag_prefix: Optional prefix to filter tags
+        project_id: Optional project identifier
+            
+    Returns:
+        Dict containing status and list of matching memory entries
+    """
+    try:
+        logger.info(f"Listing memories for agent: {agent_id}, type: {memory_type}")
+        
+        # Use agent_id as key if project_id not provided
+        store_key = project_id if project_id else agent_id
+        
+        # Initialize empty result
+        memories = []
+        
+        # Check if the store key and memory type exist
+        if (store_key in MEMORY_STORE and 
+            memory_type in MEMORY_STORE[store_key]):
+            
+            # Get all tags for this memory type
+            tags = MEMORY_STORE[store_key][memory_type].keys()
+            
+            # Filter by tag prefix if specified
+            if tag_prefix:
+                tags = [tag for tag in tags if tag.startswith(tag_prefix)]
+                
+            # Build memory entries list
+            for tag in tags:
+                memories.append({
+                    "agent_id": agent_id,
+                    "memory_type": memory_type,
+                    "tag": tag,
+                    "project_id": project_id
+                })
+        
+        return {
+            "status": "success",
+            "memories": memories,
+            "count": len(memories),
+            "agent_id": agent_id,
+            "memory_type": memory_type,
+            "tag_prefix": tag_prefix,
+            "project_id": project_id,
+            "timestamp": datetime.datetime.now().isoformat()
+        }
+    except Exception as e:
+        logger.error(f"Error listing memories: {str(e)}")
+        return {
+            "status": "error",
+            "message": f"Failed to list memories: {str(e)}",
+            "memories": [],
+            "count": 0,
+            "timestamp": datetime.datetime.now().isoformat()
+        }

--- a/logs/memory_module_fix_20250425_170430.json
+++ b/logs/memory_module_fix_20250425_170430.json
@@ -1,0 +1,18 @@
+{
+  "timestamp": "2025-04-25T17:04:30Z",
+  "event": "memory_module_fix",
+  "status": "completed",
+  "details": {
+    "issue_identified": "Parameter mismatch between orchestrator_memory.py and memory_writer.py",
+    "root_cause": "memory_writer.py functions had different parameter signatures than what orchestrator_memory.py expected",
+    "solution_implemented": {
+      "memory_writer_fix": "Updated memory_writer.py to match the parameter expectations of orchestrator_memory.py",
+      "added_functions": "Implemented list_memories function that was missing but required by dashboard_routes.py"
+    },
+    "files_modified": [
+      "app/modules/memory_writer.py"
+    ],
+    "expected_outcome": "Dashboard will be able to access memory module and display real data instead of mock data",
+    "verification_method": "Backend deployment status in Railway"
+  }
+}


### PR DESCRIPTION
## Problem
The dashboard routes were showing a warning about the memory module not being available, causing the dashboard to use mock data instead of real data. This was due to parameter mismatches between the orchestrator_memory.py module and the memory_writer.py module.

## Solution
1. Updated memory_writer.py to match the parameter expectations of orchestrator_memory.py
2. Added the missing list_memories function required by dashboard_routes.py
3. Enhanced the return values to include proper status information

## Changes
- Modified memory_writer.py to accept the correct parameters (agent_id, memory_type, tag, etc.)
- Implemented proper nested storage structure for different memory types
- Added detailed logging for easier debugging

## Expected Outcome
After deploying these changes to Railway, the dashboard should be able to access the memory module and display real data instead of mock data, which should help resolve the backend issues.